### PR TITLE
Silence console messages

### DIFF
--- a/tailscale_hook
+++ b/tailscale_hook
@@ -10,7 +10,7 @@ run_hook() {
 
 	(
 		[ -r /etc/tailscale/tailscaled.conf ] && . /etc/tailscale/tailscaled.conf
-		tailscaled -state "/etc/tailscale/tailscaled.state" -port "${tailscale_port:-41641}" $tailscaled_args &
+		( tailscaled -state "/etc/tailscale/tailscaled.state" -port "${tailscale_port:-41641}" $tailscaled_args > /dev/null 2>&1 & )
 		tailscale up --timeout="${tailscale_timeout:-20s}" $tailscale_args
 	)
 }

--- a/tailscale_hook
+++ b/tailscale_hook
@@ -10,7 +10,8 @@ run_hook() {
 
 	(
 		[ -r /etc/tailscale/tailscaled.conf ] && . /etc/tailscale/tailscaled.conf
-		( tailscaled -state "/etc/tailscale/tailscaled.state" -port "${tailscale_port:-41641}" $tailscaled_args > /tmp/tailscaled.log 2>&1 & )
+		printf "launched tailscaled at pid: "
+		tailscaled -state "/etc/tailscale/tailscaled.state" -port "${tailscale_port:-41641}" $tailscaled_args > /tmp/tailscaled.log 2>&1 &
 		tailscale up --timeout="${tailscale_timeout:-20s}" $tailscale_args
 	)
 }

--- a/tailscale_hook
+++ b/tailscale_hook
@@ -10,7 +10,7 @@ run_hook() {
 
 	(
 		[ -r /etc/tailscale/tailscaled.conf ] && . /etc/tailscale/tailscaled.conf
-		( tailscaled -state "/etc/tailscale/tailscaled.state" -port "${tailscale_port:-41641}" $tailscaled_args > /dev/null 2>&1 & )
+		( tailscaled -state "/etc/tailscale/tailscaled.state" -port "${tailscale_port:-41641}" $tailscaled_args > /tmp/tailscaled.log 2>&1 & )
 		tailscale up --timeout="${tailscale_timeout:-20s}" $tailscale_args
 	)
 }


### PR DESCRIPTION
First of all, thanks so much for this project. I just set it up with ZFSBootMenu and it works great.

One thing I noticed though is that the tailscale daemon logs start filling up the console.

If one uses ssh or tailscale ssh exclusively to unlock, they may not notice. But the console is supposed to auto load the ZBM and ask for the zfs passphrase, waiting at the prompt. Unfortunately tailscale daemon is extremely noisy and keeps outputting tons of lines, makinf the prompt quickly disappear.

The change in this PR silences the logs in the console so the passphrase prompt can sit undisturbed.

This was tested in a locally compiled ZBM EFI.

Thanks